### PR TITLE
Leading 0 GUID parse fix

### DIFF
--- a/syntax/uefic.vim
+++ b/syntax/uefic.vim
@@ -87,6 +87,7 @@ syn match	ueficOperator		"<<\|>>\|&&\|||\|++\|--\|->"
 
 hi x203_IndianRed1			ctermfg=203 guifg=#ff5f5f
 hi x220_Gold1				ctermfg=220 guifg=#ffd700
+hi x220_Purple			ctermfg=220 guifg=#161f7e
 
 " Comment
 " Constant - String Character Number Boolean Float

--- a/syntax/uefidec.vim
+++ b/syntax/uefidec.vim
@@ -29,12 +29,13 @@ syn match	decFileSep	"\/"
 syn match	decFile		"\w\(\.\|\w\|\-\)*\.\(\w\|-\)\+"
 syn match	decCommaSpace	transparent contained "\,\s+"
 syn match	decHexByte	"0\(x\|X\)\x"
-syn match	decRegistryFormatGUID	"\x\{8}\-\x\{4}-\x\{4}\-\x\{4}\-\x\{12}"
-syn region	decCFormatGUID	start="{\s*0\(x\|X\)\x\{8}\,\s\+" end="0\(x\|X\)\x\{2}\s*\}\s*\}" oneline contains=decCommaSpace
+syn match	decRegistryFormatGUID	"\x\{7,8}\-\x\{4}-\x\{4}\-\x\{4}\-\x\{12}"
+syn region	decCFormatGUID	start="{\s*0\(x\|X\)\x\{7,8}\,\s\+" end="0\(x\|X\)\x\{2}\s*\}\s*\}" oneline contains=decCommaSpace
 syn match	decNumber	display "0x\x\+\(u\=l\{0,2}\|ll\=u\)\>"
 
 
 hi x220_Gold1			ctermfg=220 guifg=#ffd700
+hi x220_Purple			ctermfg=220 guifg=#161f7e
 
 
 " Comment
@@ -57,8 +58,8 @@ hi def link decFieldSeparator	Delimiter
 " Ignore
 " Error
 " Todo
-hi def link decCFormatGUID	x220_Gold1
-hi def link decRegistryFormatGUID	x220_Gold1
+hi def link decCFormatGUID	x220_Purple
+hi def link decRegistryFormatGUID	x220_Purple
 
 
 let b:current_syntax = "uefidec"

--- a/syntax/uefidsc.vim
+++ b/syntax/uefidsc.vim
@@ -38,8 +38,8 @@ syn region dscVariable		start="\$(" skip="\\)\|\\\\" end=")"
 "syn match decFile		"\w\(\.\|\w\|\-\)*\.\(\w\|-\)\+"
 "syn match decFilePath		"\(\w\(\w\|\.\|\-\)*\)\(\/\(\w\(\w\|\.\|\-\)*\)\)*\w\(\.\|\w\|\-\)*\.\(\w\|-\)\+"
 syn match decCommaSpace		transparent contained "\,\s+"
-syn match decRegistryFormatGUID "\x\{8}\-\x\{4}-\x\{4}\-\x\{4}\-\x\{12}"
-syn region decCFormatGUID	start="{\s*0\(x\|X\)\x\{8}\,\s\+" end="0\(x\|X\)\x\{2}\s*\}\s*\}" oneline contains=decCommaSpace
+syn match decRegistryFormatGUID "\x\{7,8}\-\x\{4}-\x\{4}\-\x\{4}\-\x\{12}"
+syn region decCFormatGUID	start="{\s*0\(x\|X\)\x\{7,8}\,\s\+" end="0\(x\|X\)\x\{2}\s*\}\s*\}" oneline contains=decCommaSpace
 syn match decNumber		display "0x\x\+\(u\=l\{0,2}\|ll\=u\)\>"
 
 
@@ -48,6 +48,7 @@ hi x203_IndianRed1		ctermfg=203 guifg=#ff5f5f
 hi x208_DarkOrange		ctermfg=208 guifg=#ff8700
 hi x220_Gold1			ctermfg=220 guifg=#ffd700
 hi x228_Khaki1			gui=italic ctermfg=228 guifg=#ffff87
+hi x220_Purple			ctermfg=220 guifg=#161f7e
 
 
 " Comment
@@ -76,8 +77,8 @@ hi def link dscFieldSeparator	Delimiter
 " Ignore
 " Error
 " Todo
-hi def link decCFormatGUID	x220_Gold1
-hi def link decRegistryFormatGUID	x220_Gold1
+hi def link decCFormatGUID	x220_Purple
+hi def link decRegistryFormatGUID	x220_Purple
 
 
 let b:current_syntax = "uefidsc"

--- a/syntax/uefifdf.vim
+++ b/syntax/uefifdf.vim
@@ -36,12 +36,13 @@ syn region	dscVariable		start="\$(" skip="\\)\|\\\\" end=")"
 syn match	decFileSep	"\/"
 syn match	decFile		"\w\(\.\|\w\|\-\)*\.\(\w\|-\)\+"
 syn match	decCommaSpace	transparent contained "\,\s+"
-syn match	decRegistryFormatGUID "\x\{8}\-\x\{4}-\x\{4}\-\x\{4}\-\x\{12}"
-syn region	decCFormatGUID	start="{\s*0\(x\|X\)\x\{8}\,\s\+" end="0\(x\|X\)\x\{2}\s*\}\s*\}" oneline contains=decCommaSpace
+syn match	decRegistryFormatGUID "\x\{7,8}\-\x\{4}-\x\{4}\-\x\{4}\-\x\{12}"
+syn region	decCFormatGUID	start="{\s*0\(x\|X\)\x\{7,8}\,\s\+" end="0\(x\|X\)\x\{2}\s*\}\s*\}" oneline contains=decCommaSpace
 syn match	decNumber	display "0x\x\+\(u\=l\{0,2}\|ll\=u\)\>"
 
 
 hi x220_Gold1			ctermfg=220 guifg=#ffd700
+hi x220_Purple			ctermfg=220 guifg=#161f7e
 
 " Comment
 hi def link fdfComment		Comment
@@ -69,8 +70,8 @@ hi def link dscFieldSeparator	Delimiter
 " Ignore
 " Error
 " Todo
-hi def link decCFormatGUID	x220_Gold1
-hi def link decRegistryFormatGUID	x220_Gold1
+hi def link decCFormatGUID	x220_Purple
+hi def link decRegistryFormatGUID	x220_Purple
 
 
 let b:current_syntax = "uefidsc"


### PR DESCRIPTION
Hi I found when using this that some editors put GUIDs into the files by omitting leading 0's in the first 4 bytes. This modification touches the regex so that it works with hex strings of 7 or 8 characters instead of 8 only.

I hope that I'm properly following etiquette on GitHub for this.